### PR TITLE
Fix advanced options link

### DIFF
--- a/UI/Advanced.xml
+++ b/UI/Advanced.xml
@@ -219,7 +219,7 @@
             </Anchors>
             <Scripts>
                 <OnLoad>
-                    self.url = 'https://www.curseforge.com/wow/addons/litemount/pages/advanced-options'
+                    self.url = 'https://github.com/xod-wow/LiteMount/wiki/Advanced-Options'
                 </OnLoad>
                 <OnShow>
                     self:SetText(self.url)


### PR DESCRIPTION
The CurseForge page 404s - this updates it to what looks like the canonical spot for this documentation