### PR TITLE
Update Conditions.lua

### DIFF
--- a/Conditions.lua
+++ b/Conditions.lua
@@ -321,6 +321,15 @@ CONDITIONS["dragonridable"] = {
         end,
 }
 
+CONDITIONS["skyridable"] = {
+    name = format(L.LM_AREA_FMT_S, MOUNT_JOURNAL_FILTER_DRAGONRIDING or UNKNOWN),
+    disabled = ( IsAdvancedFlyableArea == nil ),
+    handler =
+        function (cond, context)
+            return LM.Environment:CanDragonride(context.mapPath)
+        end,
+}
+
 -- Persistent "deck of cards" draw randomness
 
 CONDITIONS["draw"] = {


### PR DESCRIPTION
add the condiition 
[skyridable]
that works the same way as 
[dragonridable]
to be consistent with Blizzards naming.

The [dragonridable] condition can/should be removed at a later point but kept for now to give people time to transition.