### PR TITLE
Make Command key available as modifier on macOS

### DIFF
--- a/Conditions.lua
+++ b/Conditions.lua
@@ -921,6 +921,14 @@ CONDITIONS["member"] = {
         end
 }
 
+local IS_MAC = IsMacClient()
+
+local function macModifiers()
+    if IS_MAC then 
+        return { val = "mod:cmd" }, { val = "mod:lcmd" }, { val = "mod:rcmd" }
+    end
+end
+
 CONDITIONS["mod"] = {
     name = L.LM_MODIFIER_KEY,
     toDisplay =
@@ -945,6 +953,7 @@ CONDITIONS["mod"] = {
         { val = "mod:shift" },
         { val = "mod:lshift" },
         { val = "mod:rshift" },
+        macModifiers(),
     },
     handler =
         function (cond, context, v)
@@ -955,10 +964,12 @@ CONDITIONS["mod"] = {
                 if IsLeftAltKeyDown() then i = i + 1 end
                 if IsLeftShiftKeyDown() then i = i + 1 end
                 if IsLeftControlKeyDown() then i = i + 1 end
+                if IS_MAC and IsLeftMetaKeyDown() then i = i + 1 end
                 if IsRightAltKeyDown() then i = i + 1 end
                 if IsRightShiftKeyDown() then i = i + 1 end
                 if IsRightControlKeyDown() then i = i + 1 end
-                if IsRightControlKeyDown() then i = i + 1 end
+                if IS_MAC and IsRightMetaKeyDown() then i = i + 1 end
+                -- if IsRightControlKeyDown() then i = i + 1 end -- XXX: twice?
                 return tonumber(v) == i
             elseif v == "alt" then
                 return IsAltKeyDown()
@@ -978,6 +989,12 @@ CONDITIONS["mod"] = {
                 return IsLeftShiftKeyDown()
             elseif v == "rshift" then
                 return IsRightShiftKeyDown()
+            elseif IS_MAC and v == "cmd" then
+                return IsMetaKeyDown()
+            elseif IS_MAC and v == "lcmd" then
+                return IsLeftMetaKeyDown()
+            elseif IS_MAC and v == "rcmd" then
+                return IsRightMetaKeyDown()
             else
                 return false
             end

--- a/UI/Bindings.lua
+++ b/UI/Bindings.lua
@@ -65,7 +65,7 @@ function LiteMountOptionsBindingsBinding_OnClick(self, button)
     LiteMountOptionsBindings_Update(LiteMountOptionsBindings)
 end
 
-local NOBINDKEYS = { "LeftButton", "RightButton", "LSHIFT", "RSHIFT", "LCTRL", "RCTRL", "LALT", "RALT" }
+local NOBINDKEYS = { "LeftButton", "RightButton", "LSHIFT", "RSHIFT", "LCTRL", "RCTRL", "LALT", "RALT", "LMETA", "RMETA" }
 
 function LiteMountOptionsBindings_OnKeyDown(self, keyOrButton)
 
@@ -100,6 +100,8 @@ function LiteMountOptionsBindings_OnKeyDown(self, keyOrButton)
         keyOrButton = "CTRL-" .. keyOrButton
     elseif IsAltKeyDown() then
         keyOrButton = "ALT-" .. keyOrButton
+    elseif IsMetaKeyDown() then
+        keyOrButton = "CMD-" .. keyOrButton
     end
 
     -- OK, let's bind something


### PR DESCRIPTION
This adds the Mac’s Command keys as selectable modifier keys for rules: 

<img width="210" alt="WoWScrnShot_040425_183222" src="https://github.com/user-attachments/assets/30d375a2-5c2e-450e-9542-a461ca81f063" />


The Command (short name: Cmd) key is the main modifier key on macOS and is in a very good thumb position (like the Windows key on Win), so it would be a shame if we couldn’t use it with LiteMount 😊

I’m using this modification for years in my local LiteMount copy. *However, what I’ve added for this pull request is the conditional function for the menu display, since the additional menu entries are of no use on non-macOS systems.* [^1]

*So, it cannot be excluded that I have intrduced a bug with the new conditional part*❗️🐞

Besided the menu display, I’ve added the `IS_MAC` condition also to the `CONDITIONS.mod.handler`. *Very likely this is superfluous,* but I cannot test if Blizz’s `IsMetaKeyDown()` function throws an error on Windows clients, so this is just to be on the safe side.

---

A note on the naming: The WoW API refers to this modifier as “meta”, however this term is not used on macOS, it is called “Command” or “Cmd” there. Also the Client GUI shows it as “Cmd”:

<img width="436" alt="WoWScrnShot_040425_180735" src="https://github.com/user-attachments/assets/c9ce3b5f-1261-4f8b-b52a-76e23b9fd096" />


---

**Important:**

In the `mod` handler, where you count the number of pressed modifiers, I noticed that [`if IsRightControlKeyDown() then i = i + 1 end` occures twice](https://github.com/xod-wow/LiteMount/blame/main/Conditions.lua#L961). I outcommented the duplicate line, but it is possible that I’m missing something and this is there for a good reason. ***Please check this!***



[^1]: Well, it is possible that it is available on Linux as meta key, and that you can remap the Win key to a meta key in the Windows registry, but I have no means to test that.