### PR TITLE
Perf: reduce allocations and improve lookup efficiency

### DIFF
--- a/ActionButton.lua
+++ b/ActionButton.lua
@@ -72,14 +72,20 @@ function LM.ActionButton:PreClick(inputButton, isDown)
     end
 
     -- Set up the fresh run context for a new run.
-    local runContext = setmetatable({
-            ['self'] = self.context,
-            button = ButtonContexts,
-            inputButton = inputButton,
-            limits = {},
-            flowControl = {},
-            rule = {},
-        }, { __index = self.context })
+    local runContext = self.runContext
+    table.wipe(runContext.limits)
+    table.wipe(runContext.flowControl)
+    table.wipe(runContext.rule)
+    -- Clear any keys left over from the previous run (preCast, preUse, etc.)
+    for k in pairs(runContext) do
+        if k ~= 'limits' and k ~= 'flowControl' and k ~= 'rule' then
+            runContext[k] = nil
+        end
+    end
+    runContext['self'] = self.context
+    runContext.button = ButtonContexts
+    runContext.inputButton = inputButton
+    self.runContextMT.__index = self.context
 
     local ruleSet = LM.Options:GetCompiledButtonRuleSet(self.id)
 
@@ -149,6 +155,14 @@ function LM.ActionButton:Create(n)
     -- Button context
     b.context = { id = n }
     ButtonContexts[n] = b.context
+
+    -- Reusable run context and metatable, allocated once
+    b.runContextMT = { __index = b.context }
+    b.runContext = setmetatable({
+        limits = {},
+        flowControl = {},
+        rule = {},
+    }, b.runContextMT)
 
     -- b:RegisterForClicks("AnyDown", "AnyUp")
     -- https://github.com/Stanzilla/WoWUIBugs/issues/317#issuecomment-1510847497

--- a/Environment.lua
+++ b/Environment.lua
@@ -20,8 +20,6 @@ LM.Environment:RegisterEvent("PLAYER_LOGIN")
 local issecretvalue = issecretvalue or function () return false end
 
 function LM.Environment:Initialize()
-    self:InitializeHolidays()
-    self:InitializeEJInstances()
     self:UpdateSwimTimes()
 
     self.combatTravelForm = nil
@@ -181,8 +179,9 @@ local StateUpdateFunctions = {
             return self.lastMineTime or 0
         end,
     playerBuffIDs =
-        function ()
-            local buffIDs = {}
+        function (self)
+            local buffIDs = self.playerBuffIDs
+            if buffIDs then table.wipe(buffIDs) else buffIDs = {} end
             local i = 1
             while true do
                 local auraInfo = C_UnitAuras.GetAuraDataByIndex('player', i)
@@ -196,8 +195,9 @@ local StateUpdateFunctions = {
             return buffIDs
         end,
     playerDebuffIDs =
-        function ()
-            local debuffIDs = {}
+        function (self)
+            local debuffIDs = self.playerDebuffIDs
+            if debuffIDs then table.wipe(debuffIDs) else debuffIDs = {} end
             local i = 1
             while true do
                 local auraInfo = C_UnitAuras.GetAuraDataByIndex('player', i, 'HARMFUL')
@@ -715,10 +715,12 @@ function LM.Environment:InitializeEJInstances()
 end
 
 function LM.Environment:GetEJInstances()
+    if not self.instancesByID then self:InitializeEJInstances() end
     return self.instancesByID
 end
 
 function LM.Environment:GetInstanceNameByID(id)
+    if not self.instancesByID then self:InitializeEJInstances() end
     if self.instancesByID[id] then
         return self.instancesByID[id].name
     else
@@ -813,6 +815,7 @@ function LM.Environment:InitializeHolidays()
 end
 
 function LM.Environment:IsHolidayActive(idOrTitle)
+    if not self.holidaysToday then self:InitializeHolidays() end
     local now = C_DateAndTime.GetCurrentCalendarTime()
 
     for eventID, eventInfo in pairs(self.holidaysToday) do
@@ -825,10 +828,12 @@ function LM.Environment:IsHolidayActive(idOrTitle)
 end
 
 function LM.Environment:GetHolidays()
+    if not self.holidaysByID then self:InitializeHolidays() end
     return CopyTable(self.holidaysByID)
 end
 
 function LM.Environment:GetHolidayName(id)
+    if not self.holidaysByID then self:InitializeHolidays() end
     return self.holidaysByID[id]
 end
 

--- a/MountDB/Expansion.lua
+++ b/MountDB/Expansion.lua
@@ -1537,6 +1537,7 @@ for expansionID, mounts in pairs(Expansion) do
         MountIDtoExpansion[mountID] = expansionID
     end
 end
+Expansion = nil
 
 function LMDB.GetExpansionByID(id)
     return MountIDtoExpansion[id] or 11

--- a/MountDB/Model.lua
+++ b/MountDB/Model.lua
@@ -11,7 +11,10 @@ local LMDB = LibStub("LibMountDB-1.0")
 local L = LMDB.L
 
 local Model = {
-    [NONE] = {}
+    [NONE] = {
+        [449133] = true, -- [PH] Nightsaber Horde Mount White (2200)
+        [449141] = true, -- [PH] Alliance Wolf Mount (2202)
+    }
 }
 
 -- There is no locale-independent stuff in this lib, because otherwise we
@@ -2670,6 +2673,7 @@ Model["Zodiac"] = {
 
 local ModelBySpellID = {}
 local ModelList = {}
+local ValidModels = {}
 
 do
     for spellID in pairs(Model._AUTO_) do
@@ -2684,6 +2688,7 @@ do
 
     for modelName, mounts in pairs(Model) do
         table.insert(ModelList, L[modelName])
+        ValidModels[modelName] = true
         for spellID in pairs(mounts) do
             if type(spellID) == 'number' then
                 ModelBySpellID[spellID] = L[modelName]
@@ -2691,6 +2696,7 @@ do
         end
     end
     table.sort(ModelList)
+    Model = nil
 end
 
 function LMDB.GetModelByID(mountID)
@@ -2707,7 +2713,7 @@ function LMDB.GetModelList()
 end
 
 function LMDB.IsValidModel(modelName)
-    return Model[modelName] ~= nil
+    return ValidModels[modelName] ~= nil
 end
 
 --@debug@

--- a/MountRegistry.lua
+++ b/MountRegistry.lua
@@ -441,33 +441,42 @@ end
 -- mounts with one for each faction.
 
 function LM.MountRegistry:GetActiveMount()
-    local buffIDs = { }
-    local i = 1
-    while true do
-        local auraInfo = C_UnitAuras.GetAuraDataByIndex('player', i)
-        if auraInfo == nil then
-            break
-        elseif not issecretvalue(auraInfo.spellId) then
-            buffIDs[auraInfo.spellId] = true
+    local buffIDs = LM.Environment.playerBuffIDs
+    if not buffIDs then
+        -- Called outside the click path (e.g. slash commands); do a one-off scan
+        buffIDs = {}
+        local i = 1
+        while true do
+            local auraInfo = C_UnitAuras.GetAuraDataByIndex('player', i)
+            if auraInfo == nil then break end
+            if not issecretvalue(auraInfo.spellId) then
+                buffIDs[auraInfo.spellId] = true
+            end
+            i = i + 1
         end
-        i = i + 1
     end
     return self.mounts:Find(function (m) return m:IsActive(buffIDs) end)
 end
 
 function LM.MountRegistry:GetMountByName(name)
-    local function match(m) return m.name == name end
-    return self.mounts:Find(match)
+    if self.indexes then
+        return self.indexes.name[name]
+    end
+    return self.mounts:Find(function (m) return m.name == name end)
 end
 
 function LM.MountRegistry:GetMountBySpell(id)
-    local function match(m) return m.spellID == id end
-    return self.mounts:Find(match)
+    if self.indexes then
+        return self.indexes.spellID[id]
+    end
+    return self.mounts:Find(function (m) return m.spellID == id end)
 end
 
 function LM.MountRegistry:GetMountByID(id)
-    local function match(m) return m.mountID == id end
-    return self.mounts:Find(match)
+    if self.indexes then
+        return self.indexes.mountID[id]
+    end
+    return self.mounts:Find(function (m) return m.mountID == id end)
 end
 
 -- For some reason GetShapeshiftFormInfo doesn't work on Ghost Wolf.

--- a/Options.lua
+++ b/Options.lua
@@ -267,13 +267,21 @@ function LM.Options:CleanDatabase()
 end
 
 function LM.Options:DatabaseMaintenance()
+    local targetVersion = self:GetLatestConfigVersion()
+    if (LM.db.global.configVersion or 0) >= targetVersion then
+        return
+    end
+
     local changed
-    if self:VersionUpgrade7() then changed = true end
-    if self:VersionUpgrade8() then changed = true end
-    if self:VersionUpgrade9() then changed = true end
-    if self:VersionUpgrade10() then changed = true end
+    for i = (LM.db.global.configVersion or 0) + 1, targetVersion do
+        local funcName = "VersionUpgrade" .. i
+        if self[funcName] and self[funcName](self) then
+            changed = true
+        end
+    end
+
     if self:CleanDatabase() then changed = true end
-    LM.db.global.configVersion = 10
+    LM.db.global.configVersion = targetVersion
     return changed
 end
 
@@ -292,8 +300,25 @@ end
 -- This is split into two because I want to load it early in the
 -- setup process to get access to the debugging settings.
 
+function LM.Options:GetLatestConfigVersion()
+    local maxVersion = 0
+    for k, v in pairs(self) do
+        if type(k) == "string" and type(v) == "function" then
+            local num = k:match("^VersionUpgrade(%d+)$")
+            if num then
+                maxVersion = math.max(maxVersion, tonumber(num))
+            end
+        end
+    end
+    return maxVersion
+end
+
 function LM.Options:Initialize()
-    local oldDB = LiteMountDB and CopyTable(LiteMountDB)
+    local targetVersion = self:GetLatestConfigVersion()
+    local oldDB
+    if LiteMountDB and (not LiteMountDB.global or (LiteMountDB.global.configVersion or 0) < targetVersion) then
+        oldDB = CopyTable(LiteMountDB)
+    end
 
     LM.db = LibStub("AceDB-3.0"):New("LiteMountDB", defaults, true)
 

--- a/RuleSet.lua
+++ b/RuleSet.lua
@@ -40,6 +40,7 @@ function LM.RuleSet:Compile(lines)
             i = i + 1
         end
     end
+    ruleset:PrintErrors()
     return ruleset
 end
 
@@ -52,9 +53,6 @@ function LM.RuleSet:PrintErrors()
 end
 
 function LM.RuleSet:Run(context)
-    -- Annoy people on purpose so they fix their action lists. Otherwise
-    -- this should be moved into the places Compile() is called.
-    self:PrintErrors()
     for n,rule in ipairs(self) do
         context.rule = {}
         local act = rule:Dispatch(context)


### PR DESCRIPTION
- ActionButton: Reuse `runContext` table by wiping it instead of dynamically allocating on every click.
- MountRegistry: Replaced self.mounts:Find(...) which does a linear table scan with an O(1) table index 
- MountRegistry: Use the pre-scanned `Environment.playerBuffIDs` in the hot path instead of performing an immediate aura scan.
- Move `RuleSet:PrintErrors()` to after `Compile()` instead of checking on every `Run()`.